### PR TITLE
Rework annotations so multiple runners do not clash

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,8 +22,8 @@ import (
 const (
 	watchAnnotationWGPublicKeyPattern = "%s.wireguard.semaphore.uw.io/pubKey"
 	watchAnnotationWGEndpointPattern  = "%s.wireguard.semaphore.uw.io/endpoint"
-	localAnnotationWGPublicKeyPattern = "%s.wireguard.semaphore.uw.io/pubKey"
-	localAnnotationWGEndpointPattern  = "%s.wireguard.semaphore.uw.io/endpoint"
+	advAnnotationWGPublicKeyPattern   = "%s.wireguard.semaphore.uw.io/pubKey"
+	advAnnotationWGEndpointPattern    = "%s.wireguard.semaphore.uw.io/endpoint"
 	wgDeviceNamePattern               = "wireguard.%s"
 )
 

--- a/main.go
+++ b/main.go
@@ -20,11 +20,9 @@ import (
 )
 
 const (
-	watchAnnotationWGPublicKeyPattern = "%s.wireguard.semaphore.uw.io/pubKey"
-	watchAnnotationWGEndpointPattern  = "%s.wireguard.semaphore.uw.io/endpoint"
-	advAnnotationWGPublicKeyPattern   = "%s.wireguard.semaphore.uw.io/pubKey"
-	advAnnotationWGEndpointPattern    = "%s.wireguard.semaphore.uw.io/endpoint"
-	wgDeviceNamePattern               = "wireguard.%s"
+	annotationWGPublicKeyPattern = "%s.wireguard.semaphore.uw.io/pubKey"
+	annotationWGEndpointPattern  = "%s.wireguard.semaphore.uw.io/endpoint"
+	wgDeviceNamePattern          = "wireguard.%s"
 )
 
 var (

--- a/runner.go
+++ b/runner.go
@@ -27,18 +27,18 @@ type Peer struct {
 // RunnerAnnotations contains the annotations that each runner should use for
 // updating its local node and watching a remote cluster.
 type RunnerAnnotations struct {
-	watchAnnotationWGPublicKey string
-	watchAnnotationWGEndpoint  string
-	advAnnotationWGPublicKey   string
-	advAnnotationWGEndpoint    string
+	watchAnnotationWGPublicKey      string
+	watchAnnotationWGEndpoint       string
+	advertisedAnnotationWGPublicKey string
+	advertisedAnnotationWGEndpoint  string
 }
 
 func constructRunnerAnnotations(localClusterName, remoteClusterName string) RunnerAnnotations {
 	return RunnerAnnotations{
-		watchAnnotationWGPublicKey: fmt.Sprintf(watchAnnotationWGPublicKeyPattern, localClusterName),
-		watchAnnotationWGEndpoint:  fmt.Sprintf(watchAnnotationWGEndpointPattern, localClusterName),
-		advAnnotationWGPublicKey:   fmt.Sprintf(advAnnotationWGPublicKeyPattern, remoteClusterName),
-		advAnnotationWGEndpoint:    fmt.Sprintf(advAnnotationWGEndpointPattern, remoteClusterName),
+		watchAnnotationWGPublicKey:      fmt.Sprintf(annotationWGPublicKeyPattern, localClusterName),
+		watchAnnotationWGEndpoint:       fmt.Sprintf(annotationWGEndpointPattern, localClusterName),
+		advertisedAnnotationWGPublicKey: fmt.Sprintf(annotationWGPublicKeyPattern, remoteClusterName),
+		advertisedAnnotationWGEndpoint:  fmt.Sprintf(annotationWGEndpointPattern, remoteClusterName),
 	}
 }
 
@@ -155,8 +155,8 @@ func (r *Runner) patchLocalNode() error {
 		return fmt.Errorf("Could not calculate wg endpoint, node internal address not found")
 	}
 	annotations := map[string]string{
-		r.annotations.advAnnotationWGPublicKey: r.device.PublicKey(),
-		r.annotations.advAnnotationWGEndpoint:  wgEndpoint,
+		r.annotations.advertisedAnnotationWGPublicKey: r.device.PublicKey(),
+		r.annotations.advertisedAnnotationWGEndpoint:  wgEndpoint,
 	}
 	if err := kube.PatchNodeAnnotation(r.client, r.nodeName, annotations); err != nil {
 		return err


### PR DESCRIPTION
An agent should be looking for an annotation that it is advertised for him on
a remote cluster (<local>.wireguard.semaphore.uw.io) and annotate it's node with
info specific for remote watchers (<remote>.wireguard.semaphore.uw.io).

For example a node running on a local cluster "aws" and having configuration for
2 remote clusters named "gcp" and "merit", should create 2 wg keys and 2
endpoints, which will be annotated on the node it is running as:
- gcp.wireguard.semaphore.uw.io/endpoint
- gcp.wireguard.semaphore.uw.io/pubKey
- merit.wireguard.semaphore.uw.io/endpoint
- merit.wireguard.semaphore.uw.io/pubKey

and should be watching remote clusters for the following:
- aws.wireguard.semaphore.uw.io/endpoint
- aws.wireguard.semaphore.uw.io/pubKey

That way we could work with multiple remotes without our runners clashing.