### PR TITLE
Update based on nodes list and fixes

### DIFF
--- a/kube/node_watcher.go
+++ b/kube/node_watcher.go
@@ -102,15 +102,15 @@ func (nw *NodeWatcher) HasSynced() bool {
 
 // List lists all nodes from the store
 func (nw *NodeWatcher) List() ([]*v1.Node, error) {
-	var svcs []*v1.Node
+	var nodes []*v1.Node
 	for _, obj := range nw.store.List() {
-		svc, ok := obj.(*v1.Node)
+		node, ok := obj.(*v1.Node)
 		if !ok {
 			return nil, fmt.Errorf("unexpected object in store: %+v", obj)
 		}
-		svcs = append(svcs, svc)
+		nodes = append(nodes, node)
 	}
-	return svcs, nil
+	return nodes, nil
 }
 
 // Healthy is true when both list and watch handlers are running without errors.

--- a/main.go
+++ b/main.go
@@ -178,8 +178,8 @@ func listenAndServe(runners []*Runner) {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}
-			w.WriteHeader(http.StatusOK)
 		}
+		w.WriteHeader(http.StatusOK)
 	})
 	server := http.Server{
 		Addr:    *flagSWGListenAddr,

--- a/runner.go
+++ b/runner.go
@@ -87,11 +87,6 @@ func (r *Runner) Run() error {
 	if err := r.patchLocalNode(); err != nil {
 		return err
 	}
-	// TODO: see if we need to set an address on the wg interface, seems
-	// that everything can work without it
-	//if err := r.setLocalDeviceAddress(); err != nil {
-	//	return err
-	//}
 	if err := r.device.FlushAddresses(); err != nil {
 		return err
 	}
@@ -186,26 +181,6 @@ func (r *Runner) patchLocalNode() error {
 		return err
 	}
 	return nil
-}
-
-// setLocalDeviceAddress gets the pod cidr from the local node spec and assignes
-// the first address to the wireguard interface.
-func (r *Runner) setLocalDeviceAddress() error {
-	ctx := context.Background()
-	node, err := r.client.CoreV1().Nodes().Get(ctx, r.nodeName, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	// TODO: derive an ip from node's spec pod cidr
-	// For now let's rely on calico
-	calicoIP, ok := node.Annotations["projectcalico.org/IPv4IPIPTunnelAddr"]
-	if !ok {
-		return fmt.Errorf("Cannot get ip from calico annotations, is calico running on the node?")
-	}
-	return r.device.UpdateAddress(&net.IPNet{
-		IP:   net.ParseIP(calicoIP),
-		Mask: net.CIDRMask(32, 32),
-	})
 }
 
 func (r *Runner) checkWSAnnotationsExist(annotations map[string]string) bool {


### PR DESCRIPTION
- Update function constructs wg peers from the nodes list to make sure it is not
  leaving stale peers behind
- Fix healthcheck response writer to write http status code once
- Rename node watcher variables