### PR TITLE
Add metrics if a sync fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,6 +109,11 @@ func main() {
 
 	makeMetricsCollector(wgMetricsClient, wgDeviceNames)
 	listenAndServe(runners)
+
+	// Stop runners before finishing
+	for _, r := range runners {
+		r.stop <- struct{}{}
+	}
 }
 
 func makeRunner(homeClient kubernetes.Interface, localName string, rConf *remoteClusterConfig) (*Runner, string, error) {


### PR DESCRIPTION
- Add metrics for sync actions and queues
- Add missing sync requeue on failure
- Stop runners sync loops before exiting