### PR TITLE
Default watchers resyncPeriod to 0 to disable it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Is a list of remote clusters that may define the following:
 
 - wgListenPort: WG listen port.
 
+- resyncPeriod: Kubernetes watcher resync period. It should yield update events
+  for everything that is stored in the cache. Default `0` value disables it.
 ## Example
 ```
 {

--- a/config.go
+++ b/config.go
@@ -41,11 +41,6 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 	}
 }
 
-var (
-	defaultWatcherResyncPeriod = Duration{time.Hour}
-	zeroDuration               = Duration{0}
-)
-
 type localClusterConfig struct {
 	Name           string `json:"name"`
 	KubeConfigPath string `json:"kubeConfigPath"`
@@ -96,9 +91,6 @@ func parseConfig(rawConfig []byte) (*Config, error) {
 		}
 		if r.WGListenPort == 0 {
 			r.WGListenPort = defaultWGListenPort
-		}
-		if r.ResyncPeriod == zeroDuration {
-			r.ResyncPeriod = defaultWatcherResyncPeriod
 		}
 	}
 	return conf, nil

--- a/config_test.go
+++ b/config_test.go
@@ -109,6 +109,6 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, "10.0.1.0/16", config.Remotes[1].PodSubnet)
 	assert.Equal(t, defaultWGDeviceMTU, config.Remotes[1].WGDeviceMTU)
 	assert.Equal(t, defaultWGListenPort, config.Remotes[1].WGListenPort)
-	assert.Equal(t, defaultWatcherResyncPeriod, config.Remotes[1].ResyncPeriod)
+	assert.Equal(t, Duration{0}, config.Remotes[1].ResyncPeriod)
 
 }


### PR DESCRIPTION
Using the default 0 duration period should instruct the watchers to avoid
re-listing from cache and getting onUpdate calls.
We should not need this, since our reconcile logic is retrying if an event fails
to update wg peers and never lets go.
https://github.com/kubernetes-sigs/controller-runtime/issues/521#issuecomment-518457302
If a watcher fails to connect to apiservers for a while it should be able to
sync when is back online and create sufficient events to sync our peers again:
https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes