### PR TITLE
Avoid stucking on Runners Run() func

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,10 +88,11 @@ func main() {
 		}
 		wgDeviceNames = append(wgDeviceNames, wgDeviceName)
 		runners = append(runners, r)
-		if err := r.Run(); err != nil {
-			log.Logger.Error("Failed to start runner", "err", err)
-			os.Exit(1)
-		}
+		go func() {
+			if err := r.Run(); err != nil {
+				log.Logger.Error("Failed to start runner", "err", err)
+			}
+		}()
 	}
 
 	wgMetricsClient, err := wgctrl.New()


### PR DESCRIPTION
The Run() function waits for node watcher's caches to be synced and can freeze
execution in case of an issue. Avoid holding main on this function since we
allow more than one clusters to be watched in parallel. Also, do not exit if one
of the runners fail to Run(), the healthcheck should be a good enough indicator
to notify us about misbehaviours.L