### PR TITLE
Use metric to monitor node watchers failures

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -32,7 +32,7 @@ var (
 	nodeWatcherFailures = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "semaphore_wg_node_watcher_failures_total",
-			Help: "Number of times the node wathcer list/watch functions errored.",
+			Help: "Number of times the node watcher list/watch functions errored.",
 		},
 		[]string{"cluster", "verb"},
 	)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -34,7 +34,7 @@ var (
 			Name: "semaphore_wg_node_watcher_failures_total",
 			Help: "Number of times the node wathcer list/watch functions errored.",
 		},
-		[]string{"cluster", "type"},
+		[]string{"cluster", "verb"},
 	)
 )
 
@@ -65,8 +65,8 @@ func Register(wgMetricsClient *wgctrl.Client, wgDeviceNames, rClusterNames []str
 	// doesn't already have a value. This ensures that all possible counters
 	// start with a 0 value.
 	for _, c := range rClusterNames {
-		for _, t := range []string{"get", "list", "create", "update", "patch", "watch", "delete"} {
-			nodeWatcherFailures.With(prometheus.Labels{"cluster": c, "type": t})
+		for _, v := range []string{"get", "list", "create", "update", "patch", "watch", "delete"} {
+			nodeWatcherFailures.With(prometheus.Labels{"cluster": c, "verb": v})
 		}
 	}
 
@@ -248,9 +248,9 @@ func IncSyncRequeue(device string) {
 	}).Inc()
 }
 
-func IncNodeWatcherFailures(c, t string) {
+func IncNodeWatcherFailures(c, v string) {
 	nodeWatcherFailures.With(prometheus.Labels{
 		"cluster": c,
-		"type":    t,
+		"verb":    v,
 	}).Inc()
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,4 +1,4 @@
-package main
+package metrics
 
 import (
 	"fmt"


### PR DESCRIPTION
Use a new metrics to count errors happened on node watchers list/watch
fuctions. We can later use those to alert instead of quering the health endpoint
and using a readiness probe.
For this, the metrics are moved inside a separate package so we can call them
outside main