### PR TITLE
Replace old healthcheck

### DIFF
--- a/deploy/example/namespace/daemonset.yaml
+++ b/deploy/example/namespace/daemonset.yaml
@@ -41,12 +41,15 @@ spec:
             capabilities:
               add:
                 - 'NET_ADMIN'
-          readinessProbe:
+          livenessProbe:
             httpGet:
               path: /healthz
               port: readiness-port
-            periodSeconds: 10
-            failureThreshold: 1
+            periodSeconds: 30
+            failureThreshold: 6
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
       volumes:
         - name: var-lib-semaphore-wireguard
           hostPath:

--- a/kube/node_watcher.go
+++ b/kube/node_watcher.go
@@ -29,8 +29,6 @@ type NodeWatcher struct {
 	store        cache.Store
 	controller   cache.Controller
 	eventHandler NodeEventHandler
-	ListHealthy  bool
-	WatchHealthy bool
 }
 
 // NewNodeWatcher returns a new node wathcer.
@@ -53,9 +51,6 @@ func (nw *NodeWatcher) Init() {
 			if err != nil {
 				log.Logger.Error("nw: list error", "err", err)
 				metrics.IncNodeWatcherFailures(nw.clusterName, "list")
-				nw.ListHealthy = false
-			} else {
-				nw.ListHealthy = true
 			}
 			return l, err
 		},
@@ -64,9 +59,6 @@ func (nw *NodeWatcher) Init() {
 			if err != nil {
 				log.Logger.Error("nw: watch error", "err", err)
 				metrics.IncNodeWatcherFailures(nw.clusterName, "watch")
-				nw.WatchHealthy = false
-			} else {
-				nw.WatchHealthy = true
 			}
 			return w, err
 		},
@@ -116,9 +108,4 @@ func (nw *NodeWatcher) List() ([]*v1.Node, error) {
 		nodes = append(nodes, node)
 	}
 	return nodes, nil
-}
-
-// Healthy is true when both list and watch handlers are running without errors.
-func (nw *NodeWatcher) Healthy() bool {
-	return nw.ListHealthy && nw.WatchHealthy
 }

--- a/main.go
+++ b/main.go
@@ -162,8 +162,12 @@ func listenAndServe(runners []*Runner) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		// if we reach listenAndServe func the wg devices should have
+		// been intialised and running. One could use the ruuners'
+		// initialised flag for a liveness probe to kick the deployment
+		// after some time
 		for _, r := range runners {
-			if !r.Healthy() {
+			if !r.initialised {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -225,6 +225,7 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
+// SyncPeerAttempt increases the counter for attempts to sync wg peers
 func SyncPeerAttempt(device string, err error) {
 	s := "1"
 	if err != nil {
@@ -236,18 +237,21 @@ func SyncPeerAttempt(device string, err error) {
 	}).Inc()
 }
 
+// IncSyncQueueFullFailures increases sync queue failures counter
 func IncSyncQueueFullFailures(device string) {
 	syncQueueFullFailures.With(prometheus.Labels{
 		"device": device,
 	}).Inc()
 }
 
+// IncSyncRequeue increases requeue counter
 func IncSyncRequeue(device string) {
 	syncRequeue.With(prometheus.Labels{
 		"device": device,
 	}).Inc()
 }
 
+// IncNodeWatcherFailures increases node watcher failures counter
 func IncNodeWatcherFailures(c, v string) {
 	nodeWatcherFailures.With(prometheus.Labels{
 		"cluster": c,


### PR DESCRIPTION
- We can use metrics now to determine the status of our watchers
- Replace old readinessProbe strategy, with a simpler health endpoint we could
potentially use for a liveness probe to kick the deployment if the runners fail
to initialise the wg interfaces and watchers after some time.