### PR TITLE
Validate wireguard interface names before creation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,21 +76,29 @@ as our local cluster name for a particular deployment, the same name should be
 set as the remote cluster name in other deployments that will try to pair with
 the local cluster.
 
+## Cluster Names Length
+
+We are using the configured cluster names to construct the respective WireGuard
+interfaces on the host, prefixing names with `wireguard.`. Because there is a
+limit on how many chars length the interfaces can be, our prefix allows the
+user to define cluster names with up to 6 characters, otherwise a validation
+[error](/utils.go#L9-L11) will be raised.
+
 ## Example
 
-`cluster1` configuration:
+Cluster1 (`c1`) configuration:
 
 ```
 {
   "local": {
-    "name": "cluster1"
+    "name": "c1"
   },
   "remotes": [
     {
-      "name": "cluster2",
-      "remoteAPIURL": "https://lb.cluster2.k8s.uw.systems",
-      "remoteCAURL": "https://kube-ca-cert.cluster2.uw.systems",
-      "remoteSATokenPath": "/etc/semaphore-wireguard/tokens/cluster2/token",
+      "name": "c2",
+      "remoteAPIURL": "https://lb.c2.k8s.uw.systems",
+      "remoteCAURL": "https://kube-ca-cert.c2.uw.systems",
+      "remoteSATokenPath": "/etc/semaphore-wireguard/tokens/c2/token",
       "podSubnet": "10.4.0.0/16",
       "wgDeviceMTU": 1380,
       "wgListenPort": 51821
@@ -99,19 +107,19 @@ the local cluster.
 }
 ```
 
-`cluster2` configuration:
+Cluster2 (`c2`) configuration:
 
 ```
 {
   "local": {
-    "name": "cluster2"
+    "name": "c2"
   },
   "remotes": [
     {
-      "name": "cluster1",
-      "remoteAPIURL": "https://lb.cluster1.k8s.uw.systems",
-      "remoteCAURL": "https://kube-ca-cert.cluster1.uw.systems",
-      "remoteSATokenPath": "/etc/semaphore-wireguard/tokens/cluster1/token",
+      "name": "c1",
+      "remoteAPIURL": "https://lb.c1.k8s.uw.systems",
+      "remoteCAURL": "https://kube-ca-cert.c1.uw.systems",
+      "remoteSATokenPath": "/etc/semaphore-wireguard/tokens/c1/token",
       "podSubnet": "10.2.0.0/16",
       "wgDeviceMTU": 1380,
       "wgListenPort": 51821

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ A json config is expected to define all the needed information regarding the
 local and the remote clusters that semaphore-wireguard operates on.
 
 ## Local
-- name: the name of the local cluster, it will be used on the created nodes
-  annotations (<name>.wireguard.semaphore.uw.io)
+- name: the name of the local cluster. This will be used by the controller to
+  look for WireGuard configuration in remote nodes' annotations, based on the
+  pattern: <name>.wireguard.semaphore.uw.io.
 
 ## Remotes
 Is a list of remote clusters that may define the following:
 - name: The name of the remote cluster. This will be used when creating the
-  local wireguard interfaces (wireguard.<name>) and for watching annotations on
-  remote clusters nodes (annotation pattern as the local config above). Thus,
-  a remote deployment that uses the same name as local should exist.
+  local wireguard interfaces (wireguard.<name>) and annotations to expose the
+  needed configuration for remote clusters controllers.
 
 - remoteAPIURL: The kube apiserver url for the remote cluster.
 
@@ -56,7 +56,10 @@ Is a list of remote clusters that may define the following:
   3 above configuration options.
 
 - podSubnet: The cluster's pod subnet. Will be used to configure a static route
-  to the subnet via the created wg interface
+  to the subnet via the created wg interface. Pod subnets should be unique
+  across the configuration, so that routes to different clusters pods do not
+  overlap. As a result, clusters which use the same subnet for pods cannot be
+  paired.
 
 - wgDeviceMTU: MTU for the created wireguard interface.
 
@@ -64,19 +67,52 @@ Is a list of remote clusters that may define the following:
 
 - resyncPeriod: Kubernetes watcher resync period. It should yield update events
   for everything that is stored in the cache. Default `0` value disables it.
+
+## Cluster Naming Consistency
+
+Cluster names should be unique and consistent across configuration of different
+deployments that live in different clusters. For example, if we pick `cluster1`
+as our local cluster name for a particular deployment, the same name should be
+set as the remote cluster name in other deployments that will try to pair with
+the local cluster.
+
 ## Example
+
+`cluster1` configuration:
+
 ```
 {
   "local": {
-    "name": "local"
+    "name": "cluster1"
   },
   "remotes": [
     {
-      "name": "remote1",
-      "remoteAPIURL": "https://lb.master.k8s.uw.systems",
-      "remoteCAURL": "https://kube-ca-cert.uw.systems",
-      "remoteSATokenPath": "/etc/semaphore-wireguard/tokens/gcp/token",
+      "name": "cluster2",
+      "remoteAPIURL": "https://lb.cluster2.k8s.uw.systems",
+      "remoteCAURL": "https://kube-ca-cert.cluster2.uw.systems",
+      "remoteSATokenPath": "/etc/semaphore-wireguard/tokens/cluster2/token",
       "podSubnet": "10.4.0.0/16",
+      "wgDeviceMTU": 1380,
+      "wgListenPort": 51821
+    }
+  ]
+}
+```
+
+`cluster2` configuration:
+
+```
+{
+  "local": {
+    "name": "cluster2"
+  },
+  "remotes": [
+    {
+      "name": "cluster1",
+      "remoteAPIURL": "https://lb.cluster1.k8s.uw.systems",
+      "remoteCAURL": "https://kube-ca-cert.cluster1.uw.systems",
+      "remoteSATokenPath": "/etc/semaphore-wireguard/tokens/cluster1/token",
+      "podSubnet": "10.2.0.0/16",
       "wgDeviceMTU": 1380,
       "wgListenPort": 51821
     }

--- a/deploy/example/namespace/resources/semaphore-wireguard-config.json
+++ b/deploy/example/namespace/resources/semaphore-wireguard-config.json
@@ -1,13 +1,13 @@
 {
   "local": {
-    "name": "cluster1"
+    "name": "c1"
   },
   "remotes": [
     {
-      "name": "cluster2",
-      "remoteAPIURL": "https://lb.cluster2.k8s.uw.systems",
-      "remoteCAURL": "https://kube-ca-cert.cluster2.uw.systems",
-      "remoteSATokenPath": "/etc/semaphore-wireguard/tokens/cluster2/token",
+      "name": "c2",
+      "remoteAPIURL": "https://lb.c2.k8s.uw.systems",
+      "remoteCAURL": "https://kube-ca-cert.c2.uw.systems",
+      "remoteSATokenPath": "/etc/semaphore-wireguard/tokens/c2/token",
       "podSubnet": "10.2.0.0/16",
       "wgListenPort": 51821
     }

--- a/deploy/example/namespace/resources/semaphore-wireguard-config.json
+++ b/deploy/example/namespace/resources/semaphore-wireguard-config.json
@@ -1,13 +1,13 @@
 {
   "local": {
-    "name": "local"
+    "name": "cluster1"
   },
   "remotes": [
     {
-      "name": "remote1",
-      "remoteAPIURL": "https://lb.master.k8s.uw.systems",
-      "remoteCAURL": "https://kube-ca-cert.uw.systems",
-      "remoteSATokenPath": "/etc/semaphore-wireguard/tokens/remote1/token",
+      "name": "cluster2",
+      "remoteAPIURL": "https://lb.cluster2.k8s.uw.systems",
+      "remoteCAURL": "https://kube-ca-cert.cluster2.uw.systems",
+      "remoteSATokenPath": "/etc/semaphore-wireguard/tokens/cluster2/token",
       "podSubnet": "10.2.0.0/16",
       "wgListenPort": 51821
     }

--- a/main.go
+++ b/main.go
@@ -142,6 +142,9 @@ func makeRunner(homeClient kubernetes.Interface, localName string, rConf *remote
 		return nil, "", fmt.Errorf("Cannot parse remote pod subnet: %s", err)
 	}
 	wgDeviceName := fmt.Sprintf(wgDeviceNamePattern, rConf.Name)
+	if err := verifyInterfaceName(wgDeviceName); err != nil {
+		return nil, "", fmt.Errorf("Interface name validation failed for %s : %s", wgDeviceName, err)
+	}
 	r := newRunner(
 		homeClient,
 		remoteClient,

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+var (
+	ifaceNameTooLongErr       = fmt.Errorf("Interface name length must be between 1 and 16 characters long")
+	ifaceNameContainsSpaceErr = fmt.Errorf("Interface name cannot contain spaces")
+	ifaceNameContainsSlashErr = fmt.Errorf("Interface name cannot contain '/' character")
+)
+
+func verifyInterfaceName(name string) error {
+	if len(name) == 0 || len(name) > 16 {
+		return ifaceNameTooLongErr
+	}
+	if strings.Contains(name, " ") {
+		return ifaceNameContainsSpaceErr
+	}
+	if strings.Contains(name, "/") {
+		return ifaceNameContainsSlashErr
+	}
+	return nil
+}

--- a/utils.go
+++ b/utils.go
@@ -11,6 +11,8 @@ var (
 	ifaceNameContainsSlashErr = fmt.Errorf("Interface name cannot contain '/' character")
 )
 
+// verifyInterfaceName check for a valid interface name based on:
+// https://unix.stackexchange.com/questions/451368/allowed-chars-in-linux-network-interface-names
 func verifyInterfaceName(name string) error {
 	if len(name) == 0 || len(name) > 16 {
 		return ifaceNameTooLongErr

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerifyInterfaceName(t *testing.T) {
+	err := verifyInterfaceName("")
+	assert.Equal(t, ifaceNameTooLongErr, err)
+	err = verifyInterfaceName("abcdefghijklmnopqrstuvwxyz")
+	assert.Equal(t, ifaceNameTooLongErr, err)
+	err = verifyInterfaceName(" ")
+	assert.Equal(t, ifaceNameContainsSpaceErr, err)
+	err = verifyInterfaceName("contains space")
+	assert.Equal(t, ifaceNameContainsSpaceErr, err)
+	err = verifyInterfaceName("wireguard/test")
+	assert.Equal(t, ifaceNameContainsSlashErr, err)
+	err = verifyInterfaceName("wireguard.test")
+	assert.Equal(t, nil, err)
+}


### PR DESCRIPTION
Add a function to verify that wireguard interface names will be allowed,
otherwise inform of the violation in the error.
This also changes README to try to make clusters naming in the configuration
a bit more clear.